### PR TITLE
[design/#6] Sign Input Form 공용 컴포넌트 퍼블리싱 완료

### DIFF
--- a/Frontend/src/components/public/SignInputFormBasic.tsx
+++ b/Frontend/src/components/public/SignInputFormBasic.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+function SignInputFormBasic(placeHolder: string) {
+  return (
+    <input
+      className="pl-4 w-3/4 h-24 border-2 border-solid border-gray-400 rounded-md bg-white text-3xl focus:border-blue-200"
+      placeholder={placeHolder}
+      type="text"
+    ></input>
+  );
+}
+
+export default SignInputFormBasic;

--- a/Frontend/src/components/public/SignInputFormPassword.tsx
+++ b/Frontend/src/components/public/SignInputFormPassword.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+function SignInputFormBasic(placeHolder: string) {
+  return (
+    <input
+      className="pl-4 w-3/4 h-24 border-2 border-solid border-gray-400 rounded-md bg-white text-3xl focus:border-blue-200"
+      placeholder={placeHolder}
+      type="password"
+    ></input>
+  );
+}
+
+export default SignInputFormBasic;


### PR DESCRIPTION
## 📢 기능 설명
Sign Input Form 공용 컴포넌트 퍼블리싱 완료했습니다.

Basic과 Password 두 버전을 나눴습니다. 그냥 하나도 다시 합칠 예정입니다.

<img width="886" alt="image" src="https://github.com/jinoo0306/Team-801-Mini-Project-To-Do-List/assets/133188752/484f1b1c-307c-43ab-85fd-f6c3b57b7cb7">

## 연결된 issue

close #8 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
